### PR TITLE
Actualiza README para MkDocs y elimina referencias a Hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bosques del Café
 
-Sitio de documentación sobre el reglamento y normativas de los bosques del café.
+Sitio de documentación sobre el reglamento de condominio del **Condominio Residencial Horizontal y Vertical Bosques de Café**. Una herramienta práctica creada por y para condóminos.
 
 ## 🌐 Sitio Web
 
@@ -8,23 +8,81 @@ El sitio está disponible en: **https://lagarciag.github.io/bosques_del_cafe/**
 
 ## 🚀 Desarrollo Local
 
-Para ejecutar el sitio localmente:
+### Prerrequisitos
+- Python 3.8+
+- pip
+
+### Configuración del entorno
+
+1. **Clonar el repositorio:**
+   ```bash
+   git clone https://github.com/lagarciag/bosques_del_cafe.git
+   cd bosques_del_cafe
+   ```
+
+2. **Crear entorno virtual:**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Linux/Mac
+   # o en Windows: .venv\Scripts\activate
+   ```
+
+3. **Instalar dependencias:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+### Ejecutar localmente
 
 ```bash
-hugo server --bind 0.0.0.0 --port 1313
+# Activar entorno virtual
+source .venv/bin/activate
+
+# Ejecutar servidor de desarrollo
+mkdocs serve
+
+# O especificar puerto
+mkdocs serve --dev-addr 127.0.0.1:8000
 ```
 
-El sitio estará disponible en http://localhost:1313/bosques_del_cafe/
+El sitio estará disponible en http://localhost:8000
+
+### Construir para producción
+
+```bash
+mkdocs build
+```
+
+Los archivos generados estarán en el directorio `site/`.
 
 ## 📁 Estructura del Proyecto
 
-- `content/` - Contenido del sitio en formato Markdown
-- `static/` - Archivos estáticos (PDFs, imágenes, etc.)
-- `themes/` - Tema de Hugo (Lotus Docs)
-- `hugo.toml` - Configuración del sitio
+- `docs/` - Contenido del sitio en formato Markdown
+  - `capitulos/` - Capítulos del reglamento organizados individualmente
+  - `images/` - Imágenes y logos del sitio
+  - `index.md` - Página principal
+  - `informacion-finca.md` - Información registral del condominio
+- `mkdocs.yml` - Configuración principal de MkDocs
+- `.venv/` - Entorno virtual de Python (no versionado)
+- `site/` - Sitio generado (no versionado)
 
 ## 🛠️ Tecnologías
 
-- [Hugo](https://gohugo.io/) - Generador de sitios estáticos
-- [Lotus Docs](https://github.com/colinwilson/lotusdocs) - Tema de documentación
-- GitHub Pages - Hosting del sitio
+- **[MkDocs](https://mkdocs.org/)** - Generador de sitios estáticos
+- **[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)** - Tema moderno y responsive
+- **Python** - Lenguaje base para MkDocs
+- **GitHub Pages** - Hosting del sitio
+- **GitHub Actions** - Despliegue automatizado con `mkdocs gh-deploy`
+
+## ✨ Características
+
+- 📱 **Responsive** - Optimizado para móviles y desktop
+- 🌙 **Modo oscuro/claro** - Cambio automático según preferencia del sistema
+- 🔍 **Búsqueda avanzada** - Búsqueda en tiempo real en todo el contenido
+- 📄 **Navegación organizada** - Reglamento dividido por capítulos para fácil consulta
+- 🤖 **Asistente virtual integrado** - ChatGPT personalizado para preguntas sobre el reglamento
+- 📋 **Acceso al documento original** - Enlaces directos al PDF registral oficial
+
+## ⚠️ Disclaimer
+
+Este sitio fue creado utilizando inteligencia artificial como herramienta de apoyo. Sirve como guía práctica pero puede contener errores o interpretaciones inexactas. Para consultas legales exactas, siempre consulte el documento original en PDF disponible en el sitio.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+mkdocs>=1.5.0
+mkdocs-material>=9.0.0
+mkdocs-awesome-pages-plugin>=2.9.0
+mkdocs-mermaid2-plugin>=1.1.0
+mkdocs-git-revision-date-localized-plugin>=1.2.0
+mkdocs-minify-plugin>=0.7.0
+mkdocs-glightbox>=0.3.0


### PR DESCRIPTION
- Reescribe completamente el README con instrucciones para MkDocs
- Agrega guía detallada de configuración del entorno Python
- Incluye comandos para desarrollo local con mkdocs serve
- Documenta nueva estructura del proyecto (docs/, mkdocs.yml)
- Lista tecnologías actuales: MkDocs + Material theme
- Agrega sección de características del sitio
- Incluye disclaimer sobre uso de IA
- Crea requirements.txt con todas las dependencias necesarias
- Elimina completamente referencias a Hugo, Lotus Docs y Go

🤖 Generated with [Claude Code](https://claude.ai/code)